### PR TITLE
Harden AI proxy and fix timestamp navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,11 @@ npm run dev
 
 ### 环境变量（.env.local）
 ```bash
-NEXT_PUBLIC_AI_API_KEY=你的火山方舟APIKey
-NEXT_PUBLIC_AI_API_ENDPOINT=https://ark.cn-beijing.volces.com/api/v3/chat/completions
-NEXT_PUBLIC_AI_MODEL=doubao-1.5-vision-pro-32k
+AI_API_KEY=你的火山方舟APIKey # 仅服务器可见
+AI_API_ENDPOINT=https://ark.cn-beijing.volces.com/api/v3/chat/completions
+AI_MODEL=doubao-1.5-vision-pro-32k
 ```
-说明：未配置 `API_KEY` 或 `API_ENDPOINT` 时，后端 `/api/ai-summary` 会返回示例结果；前端也会在失败时回退占位内容，保证演示可用性。
+说明：这些变量不会被注入前端 Bundle。未配置 `API_KEY` 或 `API_ENDPOINT` 时，后端 `/api/ai-summary` 会返回示例结果；前端也会在失败时回退占位内容，保证演示可用性。
 
 ## AI 接入与“视频理解”注意事项（重要）
 - 后端 `/api/ai-summary` 遵循 Doubao 的“视频理解”输入：
@@ -96,7 +96,7 @@ NEXT_PUBLIC_AI_MODEL=doubao-1.5-vision-pro-32k
 - 未配置 API 或请求失败时，前后端均回退到示例内容，保证页面可用性。
 
 ## 关键代码
-- AI 配置：`config/aiConfig.ts`
+- AI 配置：`config/aiConfig.ts`（使用服务器专用环境变量）
 - 服务端视频理解代理：`pages/api/ai-summary.ts`
 - 前端调用（视频 URL → 笔记）：`services/ai.ts` 的 `generateSummaryFromVideo()`
 - 文本摘要调用：`services/ai.ts` 的 `generateSummary()`

--- a/config/aiConfig.ts
+++ b/config/aiConfig.ts
@@ -1,5 +1,6 @@
 export const AI_CONFIG = {
-  API_KEY: process.env.NEXT_PUBLIC_AI_API_KEY || "",//Your API KEY
-  API_ENDPOINT: process.env.NEXT_PUBLIC_AI_API_ENDPOINT || "https://ark.cn-beijing.volces.com/api/v3/chat/completions",//For example
-  MODEL: process.env.NEXT_PUBLIC_AI_MODEL || "doubao-1.5-vision-pro-32k",//For example
-}; 
+  API_KEY: process.env.AI_API_KEY || "",
+  API_ENDPOINT:
+    process.env.AI_API_ENDPOINT || "https://ark.cn-beijing.volces.com/api/v3/chat/completions",
+  MODEL: process.env.AI_MODEL || "doubao-1.5-vision-pro-32k",
+};

--- a/pages/api/ai-summary.ts
+++ b/pages/api/ai-summary.ts
@@ -2,71 +2,118 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import axios from "axios";
 import { AI_CONFIG } from "@/config/aiConfig";
 
+const MOCK_SUMMARY = {
+  title: "AI 摘要 · 示例",
+  tags: ["AI 摘要"],
+  materials: [],
+  steps: [
+    { time: "00:05", desc: "提炼主题" },
+    { time: "00:18", desc: "列出要点" },
+    { time: "00:40", desc: "给出操作步骤" }
+  ],
+  notes: ["该摘要为占位内容，接入真实 API 后可替换"],
+};
+
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
-  const { videoUrl, promptTemplate } = req.body || {};
 
-  if (!videoUrl) return res.status(400).json({ error: "Missing videoUrl" });
+  const { videoUrl, promptTemplate, transcript } = req.body || {};
+  const hasVideoUrl = typeof videoUrl === "string" && videoUrl.trim().length > 0;
+  const hasTranscript = typeof transcript === "string" && transcript.trim().length > 0;
+
+  if (!hasVideoUrl && !hasTranscript) {
+    return res.status(400).json({ error: "Missing videoUrl or transcript" });
+  }
+
   // 火山方舟视频理解需要可直接拉取的视频直链（如 mp4/m3u8），B 站网页链接通常不可直接读取
-  if (/bilibili\.com/i.test(String(videoUrl))) {
+  if (hasVideoUrl && /bilibili\.com/i.test(String(videoUrl))) {
     return res.status(400).json({
-      error: "该链接不是视频直链。请提供可直接访问的 mp4/m3u8 链接，或先将视频转存到可公开访问的对象存储后再试。"
+      error:
+        "该链接不是视频直链。请提供可直接访问的 mp4/m3u8 链接，或先将视频转存到可公开访问的对象存储后再试。",
     });
   }
-  if (!AI_CONFIG.API_KEY || !AI_CONFIG.API_ENDPOINT) return res.status(200).json({
-    result: {
-      title: "AI 摘要 · 示例",
-      tags: ["AI 摘要"],
-      materials: [],
-      steps: [
-        { time: "00:05", desc: "提炼主题" },
-        { time: "00:18", desc: "列出要点" },
-        { time: "00:40", desc: "给出操作步骤" }
-      ],
-      notes: ["该摘要为占位内容，接入真实 API 后可替换"],
-    }
-  });
 
-  const prompt = promptTemplate || `你是视频理解专家。请基于整段视频内容完成如下任务：\n- 提炼视频主题（<=200字）\n- 列出关键标签（3-8个）\n- 给出关键材料或工具（如涉及）\n- 输出步骤要点（数组，每项含 {time, desc}，time 为 00:00 或 mm:ss）\n- 补充注意事项（数组）\n\n请输出严格 JSON，字段为: title, tags, materials, steps, notes；steps 为 {time, desc} 数组。`;
+  if (!AI_CONFIG.API_KEY || !AI_CONFIG.API_ENDPOINT) {
+    return res.status(200).json({ result: MOCK_SUMMARY });
+  }
 
-  const payload = {
-    model: AI_CONFIG.MODEL,
-    messages: [
-      {
-        role: "user",
-        content: [
-          { type: "input_video", video_url: videoUrl },
-          { type: "input_text", text: prompt }
-        ]
-      }
-    ],
-    max_tokens: 1024,
-    temperature: 0.3,
-    response_format: { type: "json_object" as const },
-    // 如果服务支持 JSON Schema，可在此加上 schema；否则由前端 normalize 解析
+  const headers = {
+    Authorization: `Bearer ${AI_CONFIG.API_KEY}`,
+    "Content-Type": "application/json",
   };
 
-  try {
-    const resp = await axios.post(AI_CONFIG.API_ENDPOINT, payload, {
-      headers: {
-        Authorization: `Bearer ${AI_CONFIG.API_KEY}`,
-        "Content-Type": "application/json"
+  if (hasVideoUrl) {
+    const prompt =
+      promptTemplate ||
+      `你是视频理解专家。请基于整段视频内容完成如下任务：\n- 提炼视频主题（<=200字）\n- 列出关键标签（3-8个）\n- 给出关键材料或工具（如涉及）\n- 输出步骤要点（数组，每项含 {time, desc}，time 为 00:00 或 mm:ss）\n- 补充注意事项（数组）\n\n请输出严格 JSON，字段为: title, tags, materials, steps, notes；steps 为 {time, desc} 数组。`;
+
+    const payload = {
+      model: AI_CONFIG.MODEL,
+      messages: [
+        {
+          role: "user" as const,
+          content: [
+            { type: "input_video" as const, video_url: videoUrl },
+            { type: "input_text" as const, text: prompt },
+          ],
+        },
+      ],
+      max_tokens: 1024,
+      temperature: 0.3,
+      response_format: { type: "json_object" as const },
+    };
+
+    try {
+      const resp = await axios.post(AI_CONFIG.API_ENDPOINT, payload, { headers });
+      console.log("[api/ai-summary] response:", resp.data);
+      const content = resp.data?.choices?.[0]?.message?.content;
+      return res.status(200).json({ result: content || resp.data });
+    } catch (e: any) {
+      console.warn("[api/ai-summary] failed(video):", e?.message || e);
+      if (e?.response?.status === 429) {
+        return res.status(429).json({ error: "请求频率超限，请稍后重试" });
       }
-    });
-
-    console.log("[api/ai-summary] response:", resp.data);
-
-    const content = resp.data?.choices?.[0]?.message?.content;
-    // 直接返回，前端做 normalize 处理
-    return res.status(200).json({ result: content || resp.data });
-  } catch (e: any) {
-    console.warn("[api/ai-summary] failed:", e?.message || e);
-    if (e?.response?.status === 429) {
-      return res.status(429).json({ error: "请求频率超限，请稍后重试" });
+      if (e?.response?.status === 401) {
+        return res.status(401).json({ error: "认证失败，请检查API Key" });
+      }
+      return res.status(500).json({ error: `处理视频时出错: ${e?.message || "unknown"}` });
     }
-    if (e?.response?.status === 401) {
-      return res.status(401).json({ error: "认证失败，请检查API Key" });
-    }
-    return res.status(500).json({ error: `处理视频时出错: ${e?.message || "unknown"}` });
   }
+
+  if (hasTranscript) {
+    const payload = {
+      model: AI_CONFIG.MODEL,
+      messages: [
+        {
+          role: "system" as const,
+          content: "你是一个擅长将视频转为步骤化笔记的助手。输出严格的 JSON，字段为: title,tags,materials,steps,notes；steps 为 {time,desc} 数组。",
+        },
+        {
+          role: "user" as const,
+          content: `请根据以下字幕生成结构化笔记：\n${transcript}`,
+        },
+      ],
+      response_format: { type: "json_object" as const },
+      max_tokens: 1024,
+      temperature: 0.3,
+    };
+
+    try {
+      const resp = await axios.post(AI_CONFIG.API_ENDPOINT, payload, { headers });
+      console.log("[api/ai-summary] response(text):", resp.data);
+      const content = resp.data?.choices?.[0]?.message?.content;
+      return res.status(200).json({ result: content || resp.data });
+    } catch (e: any) {
+      console.warn("[api/ai-summary] failed(text):", e?.message || e);
+      if (e?.response?.status === 429) {
+        return res.status(429).json({ error: "请求频率超限，请稍后重试" });
+      }
+      if (e?.response?.status === 401) {
+        return res.status(401).json({ error: "认证失败，请检查API Key" });
+      }
+      return res.status(500).json({ error: `处理字幕时出错: ${e?.message || "unknown"}` });
+    }
+  }
+
+  return res.status(500).json({ error: "未能处理请求" });
 }

--- a/pages/detail/[id].tsx
+++ b/pages/detail/[id].tsx
@@ -23,10 +23,25 @@ export default function Detail() {
   }
 
   const jumpToTime = (time: string) => {
-    const [mm, ss] = time.split(":" ).map((n) => parseInt(n, 10));
-    const seconds = (mm || 0) * 60 + (ss || 0);
-    const url = `${video.source}?t=${seconds}`;
-    window.open(url, "_blank");
+    const [mm = "0", ss = "0"] = time.split(":");
+    const toPositiveInt = (value: string) => {
+      const parsed = Number.parseInt(value, 10);
+      if (Number.isNaN(parsed) || parsed < 0) return 0;
+      return parsed;
+    };
+    const seconds = toPositiveInt(mm) * 60 + toPositiveInt(ss);
+
+    try {
+      const target = new URL(video.source);
+      target.searchParams.set("t", seconds.toString());
+      window.open(target.toString(), "_blank");
+      return;
+    } catch (err) {
+      console.warn("[detail] invalid video source, fallback to string concat", err);
+    }
+
+    const separator = video.source.includes("?") ? "&" : "?";
+    window.open(`${video.source}${separator}t=${seconds}`, "_blank");
   };
 
   return (

--- a/services/ai.ts
+++ b/services/ai.ts
@@ -1,5 +1,4 @@
 import axios from "axios";
-import { AI_CONFIG } from "../config/aiConfig";
 import type { Step } from "@/data/videos";
 
 export type Summary = {
@@ -8,6 +7,18 @@ export type Summary = {
   materials: string[];
   steps: Step[];
   notes: string[];
+};
+
+const FALLBACK_SUMMARY: Summary = {
+  title: "AI 摘要 · 示例",
+  tags: ["AI 摘要"],
+  materials: [],
+  steps: [
+    { time: "00:05", desc: "提炼主题" },
+    { time: "00:18", desc: "列出要点" },
+    { time: "00:40", desc: "给出操作步骤" }
+  ],
+  notes: ["该摘要为占位内容，接入真实 API 后可替换"],
 };
 
 function normalizeSummary(data: any): Summary | null {
@@ -32,15 +43,10 @@ function normalizeSummary(data: any): Summary | null {
   return null;
 }
 
-// 基于“视频 URL”的火山方舟调用，服务端代理，推荐使用
-export async function generateSummaryFromVideo(videoUrl: string, promptTemplate?: string): Promise<Summary> {
+async function requestSummary(body: Record<string, unknown>): Promise<Summary> {
   try {
-    const resp = await axios.post("/api/ai-summary", {
-      videoUrl,
-      promptTemplate,
-    });
+    const resp = await axios.post("/api/ai-summary", body);
     console.log("[ai] proxy response:", resp.data);
-
     const parsed = normalizeSummary(resp.data?.result ?? resp.data);
     if (parsed) return parsed;
   } catch (err: any) {
@@ -55,61 +61,20 @@ export async function generateSummaryFromVideo(videoUrl: string, promptTemplate?
   }
 
   return {
-    title: "AI 摘要 · 示例",
-    tags: ["AI 摘要"],
-    materials: [],
-    steps: [
-      { time: "00:05", desc: "提炼主题" },
-      { time: "00:18", desc: "列出要点" },
-      { time: "00:40", desc: "给出操作步骤" }
-    ],
-    notes: ["该摘要为占位内容，接入真实 API 后可替换"],
+    ...FALLBACK_SUMMARY,
+    tags: [...FALLBACK_SUMMARY.tags],
+    materials: [...FALLBACK_SUMMARY.materials],
+    steps: FALLBACK_SUMMARY.steps.map((step) => ({ ...step })),
+    notes: [...FALLBACK_SUMMARY.notes],
   };
+}
+
+// 基于“视频 URL”的火山方舟调用，服务端代理，推荐使用
+export async function generateSummaryFromVideo(videoUrl: string, promptTemplate?: string): Promise<Summary> {
+  return requestSummary({ videoUrl, promptTemplate });
 }
 
 // 纯文本字幕版本的调用（保留以兼容旧流程）；若你更偏好视频理解，请优先使用 generateSummaryFromVideo
 export async function generateSummary(videoTranscript: string): Promise<Summary> {
-  const payload = {
-    model: AI_CONFIG.MODEL,
-    messages: [
-      { role: "system", content: "你是一个擅长将视频转为步骤化笔记的助手。输出严格的 JSON，字段为: title,tags,materials,steps,notes；steps 为 {time,desc} 数组。" },
-      { role: "user", content: `请根据以下字幕生成结构化笔记：\n${videoTranscript}` }
-    ],
-    response_format: { type: "json_object" as const }
-  };
-
-  try {
-    if (!AI_CONFIG.API_KEY || !AI_CONFIG.API_ENDPOINT) throw new Error("AI 配置缺失，使用 mock");
-
-    const resp = await axios.post(AI_CONFIG.API_ENDPOINT, payload, {
-      headers: {
-        Authorization: `Bearer ${AI_CONFIG.API_KEY}`,
-        "Content-Type": "application/json"
-      }
-    });
-    console.log("[ai] api response:", resp.data);
-
-    const openAIContent = resp.data?.choices?.[0]?.message?.content;
-    const directJson = typeof resp.data === "object" ? resp.data : null;
-
-    let parsed: Summary | null = null;
-    parsed = normalizeSummary(openAIContent);
-    if (!parsed) parsed = normalizeSummary(directJson);
-
-    if (parsed) return parsed;
-  } catch (err: any) {
-    console.warn("[ai] failed, fallback to mock:", err?.message || err);
-  }
-
-  return {
-    title: "AI 摘要 · 示例",
-    tags: ["AI 摘要"],
-    materials: [],
-    steps: [
-      { time: "00:05", desc: "提炼主题" },
-      { time: "00:18", desc: "列出要点" },
-      { time: "00:40", desc: "给出操作步骤" }
-    ],
-    notes: ["该摘要为占位内容，接入真实 API 后可替换"],
-  };
-} 
+  return requestSummary({ transcript: videoTranscript });
+}


### PR DESCRIPTION
## Summary
- ensure the detail page jumps to timestamps correctly even when the source URL already contains query parameters
- move AI configuration to server-only environment variables and expand the `/api/ai-summary` handler to support both video and transcript requests with a shared mock fallback
- route all front-end AI requests through the backend proxy and document the new environment variables

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db4bf8d5788324836abd883803653b