### PR TITLE
Use server-side AI environment variables via backend proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,11 @@ npm run dev
 
 ### 环境变量（.env.local）
 ```bash
-NEXT_PUBLIC_AI_API_KEY=你的火山方舟APIKey
-NEXT_PUBLIC_AI_API_ENDPOINT=https://ark.cn-beijing.volces.com/api/v3/chat/completions
-NEXT_PUBLIC_AI_MODEL=doubao-1.5-vision-pro-32k
+AI_API_KEY=你的火山方舟APIKey # 仅服务器可读
+AI_API_ENDPOINT=https://ark.cn-beijing.volces.com/api/v3/chat/completions
+AI_MODEL=doubao-1.5-vision-pro-32k
 ```
-说明：未配置 `API_KEY` 或 `API_ENDPOINT` 时，后端 `/api/ai-summary` 会返回示例结果；前端也会在失败时回退占位内容，保证演示可用性。
+说明：未配置 `AI_API_KEY` 或 `AI_API_ENDPOINT` 时，后端 `/api/ai-summary` 会返回示例结果；前端也会在失败时回退占位内容，保证演示可用性。密钥通过服务端代理转发，不会下发到浏览器。
 
 ## AI 接入与“视频理解”注意事项（重要）
 - 后端 `/api/ai-summary` 遵循 Doubao 的“视频理解”输入：

--- a/config/aiConfig.ts
+++ b/config/aiConfig.ts
@@ -1,5 +1,5 @@
 export const AI_CONFIG = {
-  API_KEY: process.env.NEXT_PUBLIC_AI_API_KEY || "",//Your API KEY
-  API_ENDPOINT: process.env.NEXT_PUBLIC_AI_API_ENDPOINT || "https://ark.cn-beijing.volces.com/api/v3/chat/completions",//For example
-  MODEL: process.env.NEXT_PUBLIC_AI_MODEL || "doubao-1.5-vision-pro-32k",//For example
-}; 
+  API_KEY: process.env.AI_API_KEY || "", // Server-side API Key
+  API_ENDPOINT: process.env.AI_API_ENDPOINT || "https://ark.cn-beijing.volces.com/api/v3/chat/completions", // Server-side endpoint
+  MODEL: process.env.AI_MODEL || "doubao-1.5-vision-pro-32k", // Default model
+};

--- a/pages/api/ai-summary.ts
+++ b/pages/api/ai-summary.ts
@@ -4,11 +4,16 @@ import { AI_CONFIG } from "@/config/aiConfig";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
-  const { videoUrl, promptTemplate } = req.body || {};
+  const { videoUrl, promptTemplate, videoTranscript } = req.body || {};
 
-  if (!videoUrl) return res.status(400).json({ error: "Missing videoUrl" });
+  if (!videoUrl && !videoTranscript) {
+    return res.status(400).json({ error: "Missing videoUrl or videoTranscript" });
+  }
+
+  const normalizedVideoUrl = typeof videoUrl === "string" ? videoUrl : String(videoUrl ?? "");
+
   // 火山方舟视频理解需要可直接拉取的视频直链（如 mp4/m3u8），B 站网页链接通常不可直接读取
-  if (/bilibili\.com/i.test(String(videoUrl))) {
+  if (videoUrl && /bilibili\.com/i.test(normalizedVideoUrl)) {
     return res.status(400).json({
       error: "该链接不是视频直链。请提供可直接访问的 mp4/m3u8 链接，或先将视频转存到可公开访问的对象存储后再试。"
     });
@@ -27,24 +32,37 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     }
   });
 
-  const prompt = promptTemplate || `你是视频理解专家。请基于整段视频内容完成如下任务：\n- 提炼视频主题（<=200字）\n- 列出关键标签（3-8个）\n- 给出关键材料或工具（如涉及）\n- 输出步骤要点（数组，每项含 {time, desc}，time 为 00:00 或 mm:ss）\n- 补充注意事项（数组）\n\n请输出严格 JSON，字段为: title, tags, materials, steps, notes；steps 为 {time, desc} 数组。`;
+  const videoPrompt = promptTemplate || `你是视频理解专家。请基于整段视频内容完成如下任务：\n- 提炼视频主题（<=200字）\n- 列出关键标签（3-8个）\n- 给出关键材料或工具（如涉及）\n- 输出步骤要点（数组，每项含 {time, desc}，time 为 00:00 或 mm:ss）\n- 补充注意事项（数组）\n\n请输出严格 JSON，字段为: title, tags, materials, steps, notes；steps 为 {time, desc} 数组。`;
 
-  const payload = {
-    model: AI_CONFIG.MODEL,
-    messages: [
-      {
-        role: "user",
-        content: [
-          { type: "input_video", video_url: videoUrl },
-          { type: "input_text", text: prompt }
-        ]
+  const transcriptPrompt = `你是一个擅长将视频转为步骤化笔记的助手。输出严格的 JSON，字段为: title,tags,materials,steps,notes；steps 为 {time,desc} 数组。`;
+
+  const transcriptContent = typeof videoTranscript === "string" ? videoTranscript : String(videoTranscript ?? "");
+
+  const payload = videoUrl
+    ? {
+        model: AI_CONFIG.MODEL,
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "input_video", video_url: normalizedVideoUrl },
+              { type: "input_text", text: videoPrompt }
+            ]
+          }
+        ],
+        max_tokens: 1024,
+        temperature: 0.3,
+        response_format: { type: "json_object" as const },
+        // 如果服务支持 JSON Schema，可在此加上 schema；否则由前端 normalize 解析
       }
-    ],
-    max_tokens: 1024,
-    temperature: 0.3,
-    response_format: { type: "json_object" as const },
-    // 如果服务支持 JSON Schema，可在此加上 schema；否则由前端 normalize 解析
-  };
+    : {
+        model: AI_CONFIG.MODEL,
+        messages: [
+          { role: "system", content: transcriptPrompt },
+          { role: "user", content: `请根据以下字幕生成结构化笔记：\n${transcriptContent}` }
+        ],
+        response_format: { type: "json_object" as const },
+      };
 
   try {
     const resp = await axios.post(AI_CONFIG.API_ENDPOINT, payload, {

--- a/services/ai.ts
+++ b/services/ai.ts
@@ -1,5 +1,4 @@
 import axios from "axios";
-import { AI_CONFIG } from "../config/aiConfig";
 import type { Step } from "@/data/videos";
 
 export type Summary = {
@@ -8,6 +7,18 @@ export type Summary = {
   materials: string[];
   steps: Step[];
   notes: string[];
+};
+
+const MOCK_SUMMARY: Summary = {
+  title: "AI 摘要 · 示例",
+  tags: ["AI 摘要"],
+  materials: [],
+  steps: [
+    { time: "00:05", desc: "提炼主题" },
+    { time: "00:18", desc: "列出要点" },
+    { time: "00:40", desc: "给出操作步骤" }
+  ],
+  notes: ["该摘要为占位内容，接入真实 API 后可替换"],
 };
 
 function normalizeSummary(data: any): Summary | null {
@@ -54,62 +65,29 @@ export async function generateSummaryFromVideo(videoUrl: string, promptTemplate?
     );
   }
 
-  return {
-    title: "AI 摘要 · 示例",
-    tags: ["AI 摘要"],
-    materials: [],
-    steps: [
-      { time: "00:05", desc: "提炼主题" },
-      { time: "00:18", desc: "列出要点" },
-      { time: "00:40", desc: "给出操作步骤" }
-    ],
-    notes: ["该摘要为占位内容，接入真实 API 后可替换"],
-  };
+  return MOCK_SUMMARY;
 }
 
 // 纯文本字幕版本的调用（保留以兼容旧流程）；若你更偏好视频理解，请优先使用 generateSummaryFromVideo
 export async function generateSummary(videoTranscript: string): Promise<Summary> {
-  const payload = {
-    model: AI_CONFIG.MODEL,
-    messages: [
-      { role: "system", content: "你是一个擅长将视频转为步骤化笔记的助手。输出严格的 JSON，字段为: title,tags,materials,steps,notes；steps 为 {time,desc} 数组。" },
-      { role: "user", content: `请根据以下字幕生成结构化笔记：\n${videoTranscript}` }
-    ],
-    response_format: { type: "json_object" as const }
-  };
-
   try {
-    if (!AI_CONFIG.API_KEY || !AI_CONFIG.API_ENDPOINT) throw new Error("AI 配置缺失，使用 mock");
-
-    const resp = await axios.post(AI_CONFIG.API_ENDPOINT, payload, {
-      headers: {
-        Authorization: `Bearer ${AI_CONFIG.API_KEY}`,
-        "Content-Type": "application/json"
-      }
+    const resp = await axios.post("/api/ai-summary", {
+      videoTranscript,
     });
-    console.log("[ai] api response:", resp.data);
+    console.log("[ai] transcript proxy response:", resp.data);
 
-    const openAIContent = resp.data?.choices?.[0]?.message?.content;
-    const directJson = typeof resp.data === "object" ? resp.data : null;
-
-    let parsed: Summary | null = null;
-    parsed = normalizeSummary(openAIContent);
-    if (!parsed) parsed = normalizeSummary(directJson);
-
+    const parsed = normalizeSummary(resp.data?.result ?? resp.data);
     if (parsed) return parsed;
   } catch (err: any) {
-    console.warn("[ai] failed, fallback to mock:", err?.message || err);
+    const status = err?.response?.status;
+    const data = err?.response?.data;
+    console.warn(
+      "[ai] transcript proxy failed, fallback to mock:",
+      err?.message || err,
+      status ? `(status: ${status})` : "",
+      data ? `(data: ${typeof data === "string" ? data : JSON.stringify(data)})` : ""
+    );
   }
 
-  return {
-    title: "AI 摘要 · 示例",
-    tags: ["AI 摘要"],
-    materials: [],
-    steps: [
-      { time: "00:05", desc: "提炼主题" },
-      { time: "00:18", desc: "列出要点" },
-      { time: "00:40", desc: "给出操作步骤" }
-    ],
-    notes: ["该摘要为占位内容，接入真实 API 后可替换"],
-  };
-} 
+  return MOCK_SUMMARY;
+}


### PR DESCRIPTION
## Summary
- update the AI configuration to read server-only environment variable names
- extend `/api/ai-summary` to proxy both video and transcript summarisation requests using the server credentials
- route front-end summary helpers through the backend proxy and document the new environment variables in the README

## Testing
- npm run lint *(fails: prompts for interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68db4e7533d0832480367ceb89e33785