### PR TITLE
feat: summarize bilibili videos via subtitles

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ bilibili-knowledge-base/
 ├─ lib/                  # 辅助库（AI、bilibili 等）
 ├─ pages/                # Next.js 页面与 API 路由
 │  ├─ api/
-│  │  ├─ ai-summary.ts   # 服务端代理：视频理解 → 结构化 JSON
-│  │  ├─ bili-info.ts    # 解析/mock B 站视频基础信息
+│  │  ├─ ai-summary.ts   # 服务端代理：B 站字幕抽取 + 结构化摘要 / 视频直链理解
+│  │  ├─ bili-info.ts    # 解析 B 站视频基础信息（标题/封面/UP 主）
 │  │  └─ bili.ts         # 示例 API（mock）
 │  ├─ index.tsx          # 输入视频链接，生成笔记
 │  ├─ library.tsx        # 知识库视图
@@ -75,25 +75,21 @@ NEXT_PUBLIC_AI_MODEL=doubao-1.5-vision-pro-32k
 说明：未配置 `API_KEY` 或 `API_ENDPOINT` 时，后端 `/api/ai-summary` 会返回示例结果；前端也会在失败时回退占位内容，保证演示可用性。
 
 ## AI 接入与“视频理解”注意事项（重要）
-- 后端 `/api/ai-summary` 遵循 Doubao 的“视频理解”输入：
-  - `messages[0].content` 包含：
-    - `{ type: "input_video", video_url: <直链> }`
-    - `{ type: "input_text", text: <提示词> }`
-  - `response_format: { type: "json_object" }` 强制返回结构化 JSON。
-- 根据官方文档，“视频理解”需要可直接拉取的媒体直链（mp4/m3u8）。普通 B 站网页链接（bilibili.com/*）不是直链，接口会返回 400 并提示原因。
-- 文档参考：[火山引擎 Doubao · 视频理解](https://www.volcengine.com/docs/82379/1362931#%E8%A7%86%E9%A2%91%E7%90%86%E8%A7%A3)
+- 对于包含 BV 号的 B 站链接，后端 `/api/ai-summary` 会：
+  1. 自动抓取视频字幕（优先中文），拼接为长文本；
+  2. 调用文本模型生成结构化 JSON 摘要；
+  3. 若字幕缺失或模型不可用，回退到内置 Mock。
+- 其它可直接访问的 mp4/m3u8 直链仍按 Doubao “视频理解”接口处理：
+  - `messages[0].content` 包含 `{ type: "input_video" }` 与 `{ type: "input_text" }`；
+  - `response_format: { type: "json_object" }` 强制返回结构化 JSON；
+  - 文档参考：[火山引擎 Doubao · 视频理解](https://www.volcengine.com/docs/82379/1362931#%E8%A7%86%E9%A2%91%E7%90%86%E8%A7%A3)。
 
 ### 如何处理 B 站链接
-1) 字幕优先（推荐、稳定）
-- 服务端通过 B 站接口获取字幕（需 WBI 签名与鉴权），拼接为 transcript；改走文本摘要（`services/ai.ts` 的 `generateSummary()`）。
-- 不在前端暴露签名逻辑与凭证。
-
-2) 服务端拉流转存（需合规评估）
-- 服务端拉取 B 站流并合并音视频，上传到对象存储（TOS/S3/OSS）拿到直链，再传给 Doubao。
-- 注意版权与平台协议，关注带宽/存储/转码成本与安全。
-
-3) Mock 演示
-- 未配置 API 或请求失败时，前后端均回退到示例内容，保证页面可用性。
+1) 直接粘贴 BV 链接即可：后端会尝试字幕抽取与总结。
+2) 若该视频没有字幕 / 需要更精细的多模态理解，可考虑：
+   - 拉流转存到对象存储，获得可公开访问的直链，再交给多模态模型；
+   - 或自行提供字幕文本并调用 `services/ai.ts` 中的 `generateSummary()`。
+3) Mock 演示：当 API Key 缺失或调用失败时，依旧返回示例摘要，保障演示流程。
 
 ## 关键代码
 - AI 配置：`config/aiConfig.ts`
@@ -105,15 +101,14 @@ NEXT_PUBLIC_AI_MODEL=doubao-1.5-vision-pro-32k
 ## 使用流程（本地）
 1. 运行 `npm run dev` 打开首页。
 2. 粘贴视频链接：
-   - 若为 mp4/m3u8 直链：直接走“视频理解”。
-   - 若为 B 站网页链接：当前会提示非直链（400）。你可以：
-     - 走 Mock 演示；
-     - 或按“字幕优先/拉流转存”方案改造后端。
+   - 含 BV 号的 B 站链接会自动抓取字幕并生成摘要；
+   - 其它 mp4/m3u8 直链则走“视频理解”多模态流程。
 3. 生成后跳转“知识库”查看卡片化笔记，可进入详情页继续查看。
 
 ## FAQ（常见问题）
-- 为什么 B 站链接会报错？
-  - 因为“视频理解”需要直链。B 站页面地址通常需要登录、签名与防盗链校验。
+- 为什么个别 B 站链接依旧无法生成？
+  - 可能该视频未提供字幕、字幕需要登录才能访问，或返回的是图片类弹幕。此时接口会提示错误。
+  - 你可以尝试手动下载字幕并调用 `generateSummary()`，或改用“视频直链”方案。
 - 没有 API Key 可以用吗？
   - 可以。本项目内置 Mock 以保证演示。
 - 返回 401/429/5xx 怎么办？

--- a/lib/bilibili.ts
+++ b/lib/bilibili.ts
@@ -1,9 +1,3 @@
-export type BilibiliInfo = {
-  title: string;
-  cover: string;
-  uploader: string;
-};
-
 export function extractBV(url: string): string | null {
   try {
     const u = new URL(url);
@@ -16,24 +10,9 @@ export function extractBV(url: string): string | null {
   }
 }
 
-export async function fetchBilibiliInfo(bv: string): Promise<BilibiliInfo> {
-  // 简化：调用公开解析服务或 B 站开放 API 的代理，这里先尝试一个示例 JSON 接口
-  // 若失败返回 mock
-  try {
-    // 这里使用一个不可用的占位符，真实项目应改为你自己的代理 API
-    const resp = await fetch(`/api/bili?bv=${encodeURIComponent(bv)}`);
-    if (!resp.ok) throw new Error("bad status");
-    const data = await resp.json();
-    return {
-      title: data.title ?? `Bilibili 视频 ${bv}`,
-      cover: data.cover ?? "",
-      uploader: data.uploader ?? "未知UP主",
-    };
-  } catch {
-    return {
-      title: `示例视频 ${bv}`,
-      cover: "",
-      uploader: "示例UP主",
-    };
-  }
-} 
+export const BILIBILI_HEADERS = {
+  "User-Agent":
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
+  Referer: "https://www.bilibili.com",
+  Origin: "https://www.bilibili.com",
+};

--- a/lib/summary.ts
+++ b/lib/summary.ts
@@ -1,0 +1,45 @@
+import type { Step } from "@/data/videos";
+
+export type Summary = {
+  title: string;
+  tags: string[];
+  materials: string[];
+  steps: Step[];
+  notes: string[];
+};
+
+export function normalizeSummary(data: any): Summary | null {
+  try {
+    if (!data) return null;
+    const obj = typeof data === "string" ? JSON.parse(data) : data;
+    if (
+      typeof obj.title === "string" &&
+      Array.isArray(obj.tags) &&
+      Array.isArray(obj.steps) &&
+      Array.isArray(obj.notes)
+    ) {
+      return {
+        title: obj.title,
+        tags: obj.tags,
+        materials: Array.isArray(obj.materials) ? obj.materials : [],
+        steps: obj.steps.map((s: any) => ({ time: String(s.time ?? ""), desc: String(s.desc ?? "") })),
+        notes: obj.notes.map((n: any) => String(n)),
+      };
+    }
+  } catch {}
+  return null;
+}
+
+export function createMockSummary(): Summary {
+  return {
+    title: "AI 摘要 · 示例",
+    tags: ["AI 摘要"],
+    materials: [],
+    steps: [
+      { time: "00:05", desc: "提炼主题" },
+      { time: "00:18", desc: "列出要点" },
+      { time: "00:40", desc: "给出操作步骤" }
+    ],
+    notes: ["该摘要为占位内容，接入真实 API 后可替换"],
+  };
+}

--- a/pages/api/ai-summary.ts
+++ b/pages/api/ai-summary.ts
@@ -1,34 +1,154 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import axios from "axios";
 import { AI_CONFIG } from "@/config/aiConfig";
+import { BILIBILI_HEADERS, extractBV } from "@/lib/bilibili";
+import { createMockSummary, normalizeSummary, Summary } from "@/lib/summary";
 
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
-  const { videoUrl, promptTemplate } = req.body || {};
+const DEFAULT_VIDEO_PROMPT = `你是视频理解专家。请基于整段视频内容完成如下任务：\n- 提炼视频主题（<=200字）\n- 列出关键标签（3-8个）\n- 给出关键材料或工具（如涉及）\n- 输出步骤要点（数组，每项含 {time, desc}，time 为 00:00 或 mm:ss）\n- 补充注意事项（数组）\n\n请输出严格 JSON，字段为: title, tags, materials, steps, notes；steps 为 {time, desc} 数组。`;
 
-  if (!videoUrl) return res.status(400).json({ error: "Missing videoUrl" });
-  // 火山方舟视频理解需要可直接拉取的视频直链（如 mp4/m3u8），B 站网页链接通常不可直接读取
-  if (/bilibili\.com/i.test(String(videoUrl))) {
-    return res.status(400).json({
-      error: "该链接不是视频直链。请提供可直接访问的 mp4/m3u8 链接，或先将视频转存到可公开访问的对象存储后再试。"
-    });
+const SUBTITLE_SYSTEM_PROMPT =
+  "你是一个擅长将视频字幕整理为结构化知识卡片的助手。请使用严格的 JSON 输出，字段为 title, tags, materials, steps, notes；steps 为 {time, desc} 数组。";
+
+const MAX_TRANSCRIPT_LENGTH = 12000;
+
+type SubtitleMeta = {
+  transcriptLength: number;
+  truncatedLength: number;
+  bv: string;
+  aid?: number;
+  cid?: number;
+  partTitle?: string;
+  subtitleLanguage?: string;
+  usedMock: boolean;
+};
+
+function buildSubtitlePrompt(transcript: string, promptTemplate?: string): string {
+  if (!promptTemplate) {
+    return `请根据以下字幕生成结构化笔记：\n${transcript}`;
   }
-  if (!AI_CONFIG.API_KEY || !AI_CONFIG.API_ENDPOINT) return res.status(200).json({
-    result: {
-      title: "AI 摘要 · 示例",
-      tags: ["AI 摘要"],
-      materials: [],
-      steps: [
-        { time: "00:05", desc: "提炼主题" },
-        { time: "00:18", desc: "列出要点" },
-        { time: "00:40", desc: "给出操作步骤" }
-      ],
-      notes: ["该摘要为占位内容，接入真实 API 后可替换"],
-    }
+  if (/\{\{\s*(transcript|content)\s*\}\}/i.test(promptTemplate)) {
+    return promptTemplate.replace(/\{\{\s*(transcript|content)\s*\}\}/gi, transcript);
+  }
+  return `${promptTemplate}\n\n字幕内容：\n${transcript}`;
+}
+
+async function fetchBilibiliSubtitle(bv: string) {
+  const viewResp = await axios.get("https://api.bilibili.com/x/web-interface/view", {
+    params: { bvid: bv },
+    headers: BILIBILI_HEADERS,
   });
 
-  const prompt = promptTemplate || `你是视频理解专家。请基于整段视频内容完成如下任务：\n- 提炼视频主题（<=200字）\n- 列出关键标签（3-8个）\n- 给出关键材料或工具（如涉及）\n- 输出步骤要点（数组，每项含 {time, desc}，time 为 00:00 或 mm:ss）\n- 补充注意事项（数组）\n\n请输出严格 JSON，字段为: title, tags, materials, steps, notes；steps 为 {time, desc} 数组。`;
+  if (viewResp.data?.code !== 0 || !viewResp.data?.data) {
+    throw new Error(`获取视频信息失败: code=${viewResp.data?.code}`);
+  }
 
+  const data = viewResp.data.data;
+  const aid = data.aid as number | undefined;
+  const pages = Array.isArray(data.pages) ? data.pages : [];
+  const firstPage = pages[0];
+  const cid = (firstPage?.cid ?? data.cid) as number | undefined;
+  if (!cid || !aid) {
+    throw new Error("未获取到视频的 cid/aid，可能是付费或限制视频");
+  }
+
+  const playerResp = await axios.get("https://api.bilibili.com/x/player/v2", {
+    params: { aid, cid, bvid: bv },
+    headers: BILIBILI_HEADERS,
+  });
+  const subtitles: any[] = playerResp.data?.data?.subtitle?.subtitles || [];
+  if (!subtitles.length) {
+    throw new Error("该视频未提供可下载的字幕");
+  }
+
+  const preferred =
+    subtitles.find((s) => s.lan === "zh-CN") ||
+    subtitles.find((s) => typeof s.lan === "string" && s.lan.toLowerCase().startsWith("zh")) ||
+    subtitles[0];
+
+  if (!preferred?.subtitle_url) {
+    throw new Error("字幕链接无效");
+  }
+
+  const subtitleUrl = preferred.subtitle_url.startsWith("http")
+    ? preferred.subtitle_url
+    : `https:${preferred.subtitle_url}`;
+
+  const subtitleResp = await axios.get(subtitleUrl, { headers: BILIBILI_HEADERS });
+  const body: any[] = Array.isArray(subtitleResp.data?.body) ? subtitleResp.data.body : [];
+  if (!body.length) {
+    throw new Error("字幕文件为空");
+  }
+
+  const contents = body
+    .map((item) => (typeof item?.content === "string" ? item.content.trim() : ""))
+    .filter(Boolean);
+  const transcript = contents.join("\n");
+
+  const truncatedTranscript =
+    transcript.length > MAX_TRANSCRIPT_LENGTH
+      ? `${transcript.slice(0, MAX_TRANSCRIPT_LENGTH)}\n（字幕过长，后续内容已截断用于摘要生成）`
+      : transcript;
+
+  return {
+    transcript,
+    truncatedTranscript,
+    meta: {
+      transcriptLength: transcript.length,
+      truncatedLength: truncatedTranscript.length,
+      bv,
+      aid,
+      cid,
+      partTitle: firstPage?.part ?? data.title,
+      subtitleLanguage: preferred?.lan_doc || preferred?.lan,
+    },
+  };
+}
+
+async function summarizeWithSubtitles(transcript: string, promptTemplate?: string): Promise<{ summary: Summary; usedMock: boolean }> {
+  const prompt = buildSubtitlePrompt(transcript, promptTemplate);
+
+  if (!AI_CONFIG.API_KEY || !AI_CONFIG.API_ENDPOINT) {
+    console.warn("[api/ai-summary] AI 配置缺失，使用 mock 结果");
+    return { summary: createMockSummary(), usedMock: true };
+  }
+
+  const payload = {
+    model: AI_CONFIG.MODEL,
+    messages: [
+      { role: "system", content: SUBTITLE_SYSTEM_PROMPT },
+      { role: "user", content: prompt },
+    ],
+    response_format: { type: "json_object" as const },
+  };
+
+  try {
+    const resp = await axios.post(AI_CONFIG.API_ENDPOINT, payload, {
+      headers: {
+        Authorization: `Bearer ${AI_CONFIG.API_KEY}`,
+        "Content-Type": "application/json",
+      },
+    });
+
+    const content = resp.data?.choices?.[0]?.message?.content;
+    const parsed = normalizeSummary(content) || normalizeSummary(resp.data);
+    if (parsed) {
+      return { summary: parsed, usedMock: false };
+    }
+
+    throw new Error("模型输出解析失败");
+  } catch (err: any) {
+    console.warn("[api/ai-summary] 字幕模式调用失败:", err?.message || err);
+    return { summary: createMockSummary(), usedMock: true };
+  }
+}
+
+async function summarizeVideoByUrl(videoUrl: string, promptTemplate?: string): Promise<{ summary: Summary; usedMock: boolean }> {
+  if (!AI_CONFIG.API_KEY || !AI_CONFIG.API_ENDPOINT) {
+    console.warn("[api/ai-summary] AI 配置缺失，使用 mock 结果");
+    return { summary: createMockSummary(), usedMock: true };
+  }
+
+  const prompt = promptTemplate || DEFAULT_VIDEO_PROMPT;
   const payload = {
     model: AI_CONFIG.MODEL,
     messages: [
@@ -36,37 +156,77 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         role: "user",
         content: [
           { type: "input_video", video_url: videoUrl },
-          { type: "input_text", text: prompt }
-        ]
-      }
+          { type: "input_text", text: prompt },
+        ],
+      },
     ],
     max_tokens: 1024,
     temperature: 0.3,
     response_format: { type: "json_object" as const },
-    // 如果服务支持 JSON Schema，可在此加上 schema；否则由前端 normalize 解析
   };
 
   try {
     const resp = await axios.post(AI_CONFIG.API_ENDPOINT, payload, {
       headers: {
         Authorization: `Bearer ${AI_CONFIG.API_KEY}`,
-        "Content-Type": "application/json"
-      }
+        "Content-Type": "application/json",
+      },
     });
 
-    console.log("[api/ai-summary] response:", resp.data);
-
     const content = resp.data?.choices?.[0]?.message?.content;
-    // 直接返回，前端做 normalize 处理
-    return res.status(200).json({ result: content || resp.data });
-  } catch (e: any) {
-    console.warn("[api/ai-summary] failed:", e?.message || e);
-    if (e?.response?.status === 429) {
-      return res.status(429).json({ error: "请求频率超限，请稍后重试" });
+    const parsed = normalizeSummary(content) || normalizeSummary(resp.data);
+    if (parsed) {
+      return { summary: parsed, usedMock: false };
     }
-    if (e?.response?.status === 401) {
-      return res.status(401).json({ error: "认证失败，请检查API Key" });
-    }
-    return res.status(500).json({ error: `处理视频时出错: ${e?.message || "unknown"}` });
+
+    throw new Error("模型输出解析失败");
+  } catch (err: any) {
+    console.warn("[api/ai-summary] 视频模式调用失败:", err?.message || err);
+    return { summary: createMockSummary(), usedMock: true };
   }
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
+  const { videoUrl, promptTemplate } = req.body || {};
+
+  if (!videoUrl) return res.status(400).json({ error: "Missing videoUrl" });
+
+  const bv = extractBV(String(videoUrl));
+
+  if (bv) {
+    try {
+      const { transcript, truncatedTranscript, meta } = await fetchBilibiliSubtitle(bv);
+      const { summary, usedMock } = await summarizeWithSubtitles(truncatedTranscript, promptTemplate);
+      const subtitleMeta: SubtitleMeta = {
+        ...meta,
+        usedMock,
+      };
+      return res.status(200).json({
+        result: summary,
+        meta: {
+          mode: "bilibili-subtitle",
+          subtitle: subtitleMeta,
+        },
+      });
+    } catch (err: any) {
+      return res.status(500).json({ error: err?.message || "处理字幕时出错" });
+    }
+  }
+
+  // 非 B 站视频，保持兼容原有的“直链视频理解”流程
+  if (/bilibili\.com/i.test(String(videoUrl))) {
+    return res.status(400).json({
+      error: "该链接不是视频直链。请提供可直接访问的 mp4/m3u8 链接，或先将视频转存到可公开访问的对象存储后再试。",
+    });
+  }
+
+  const { summary, usedMock } = await summarizeVideoByUrl(videoUrl, promptTemplate);
+  return res.status(200).json({
+    result: summary,
+    meta: {
+      mode: "direct-video",
+      usedMock,
+    },
+  });
 }

--- a/pages/api/bili-info.ts
+++ b/pages/api/bili-info.ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import axios from "axios";
+import { BILIBILI_HEADERS } from "@/lib/bilibili";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const { bv } = req.query;
@@ -8,18 +9,20 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   try {
-    // 示例：调用某个可用的解析服务或你自建后端
-    // 注意：B 站官方开放 API 需要凭证/签名，这里不直接暴露。建议在服务端完成。
-    // const resp = await axios.get(`https://your-proxy.example.com/bili/info`, { params: { bv } });
-    // console.log("[api/bili-info] proxy response:", resp.data);
-    // return res.status(200).json(resp.data);
+    const resp = await axios.get("https://api.bilibili.com/x/web-interface/view", {
+      params: { bvid: bv },
+      headers: BILIBILI_HEADERS,
+    });
 
-    // 暂时返回 mock，并打印日志
-    console.log("[api/bili-info] using mock response for bv:", bv);
+    if (resp.data?.code !== 0 || !resp.data?.data) {
+      throw new Error(`unexpected response code: ${resp.data?.code}`);
+    }
+
+    const data = resp.data.data;
     return res.status(200).json({
-      title: `示例标题 - ${bv}`,
-      cover: "",
-      uploader: "示例UP主",
+      title: data.title ?? `示例标题 - ${bv}`,
+      cover: data.pic ?? "",
+      uploader: data.owner?.name ?? "未知UP主",
     });
   } catch (err: any) {
     console.warn("[api/bili-info] proxy failed:", err?.message || err);
@@ -29,4 +32,4 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       uploader: "示例UP主",
     });
   }
-} 
+}

--- a/services/ai.ts
+++ b/services/ai.ts
@@ -1,36 +1,6 @@
 import axios from "axios";
 import { AI_CONFIG } from "../config/aiConfig";
-import type { Step } from "@/data/videos";
-
-export type Summary = {
-  title: string;
-  tags: string[];
-  materials: string[];
-  steps: Step[];
-  notes: string[];
-};
-
-function normalizeSummary(data: any): Summary | null {
-  try {
-    if (!data) return null;
-    const obj = typeof data === "string" ? JSON.parse(data) : data;
-    if (
-      typeof obj.title === "string" &&
-      Array.isArray(obj.tags) &&
-      Array.isArray(obj.steps) &&
-      Array.isArray(obj.notes)
-    ) {
-      return {
-        title: obj.title,
-        tags: obj.tags,
-        materials: Array.isArray(obj.materials) ? obj.materials : [],
-        steps: obj.steps.map((s: any) => ({ time: String(s.time ?? ""), desc: String(s.desc ?? "") })),
-        notes: obj.notes.map((n: any) => String(n)),
-      };
-    }
-  } catch {}
-  return null;
-}
+import { createMockSummary, normalizeSummary, Summary } from "@/lib/summary";
 
 // 基于“视频 URL”的火山方舟调用，服务端代理，推荐使用
 export async function generateSummaryFromVideo(videoUrl: string, promptTemplate?: string): Promise<Summary> {
@@ -54,17 +24,7 @@ export async function generateSummaryFromVideo(videoUrl: string, promptTemplate?
     );
   }
 
-  return {
-    title: "AI 摘要 · 示例",
-    tags: ["AI 摘要"],
-    materials: [],
-    steps: [
-      { time: "00:05", desc: "提炼主题" },
-      { time: "00:18", desc: "列出要点" },
-      { time: "00:40", desc: "给出操作步骤" }
-    ],
-    notes: ["该摘要为占位内容，接入真实 API 后可替换"],
-  };
+  return createMockSummary();
 }
 
 // 纯文本字幕版本的调用（保留以兼容旧流程）；若你更偏好视频理解，请优先使用 generateSummaryFromVideo
@@ -101,15 +61,5 @@ export async function generateSummary(videoTranscript: string): Promise<Summary>
     console.warn("[ai] failed, fallback to mock:", err?.message || err);
   }
 
-  return {
-    title: "AI 摘要 · 示例",
-    tags: ["AI 摘要"],
-    materials: [],
-    steps: [
-      { time: "00:05", desc: "提炼主题" },
-      { time: "00:18", desc: "列出要点" },
-      { time: "00:40", desc: "给出操作步骤" }
-    ],
-    notes: ["该摘要为占位内容，接入真实 API 后可替换"],
-  };
-} 
+  return createMockSummary();
+}

--- a/services/bilibili.ts
+++ b/services/bilibili.ts
@@ -1,17 +1,9 @@
 import axios from "axios";
+import { extractBV as extractBVFromLib } from "@/lib/bilibili";
 
 export type BiliInfo = { title: string; cover: string; uploader: string };
 
-export function extractBV(url: string): string | null {
-  try {
-    const u = new URL(url);
-    const match = u.pathname.match(/BV[\w]+/i);
-    return match ? match[0] : null;
-  } catch {
-    const match = (url || "").match(/BV[\w]+/i);
-    return match ? match[0] : null;
-  }
-}
+export const extractBV = extractBVFromLib;
 
 export async function getBilibiliVideoInfo(bv: string | null): Promise<BiliInfo> {
   if (!bv) return { title: "", cover: "", uploader: "" };
@@ -23,4 +15,4 @@ export async function getBilibiliVideoInfo(bv: string | null): Promise<BiliInfo>
     console.warn("[bili-info] failed, fallback to mock:", err?.message || err);
     return { title: `示例标题 - ${bv}`, cover: "", uploader: "示例UP主" };
   }
-} 
+}


### PR DESCRIPTION
## Summary
- fetch Bilibili subtitles server-side and summarize transcripts when BV links are provided
- share summary normalization helpers and update client services to reuse the parsing utilities
- document the subtitle-first workflow and enable real metadata fetching for Bilibili videos

## Testing
- npm run lint (fails: interactive ESLint setup prompt)


------
https://chatgpt.com/codex/tasks/task_e_68f2f000f03483248070579a16411797